### PR TITLE
Update max_length of "Location" member for various objects to be 128 characters . . . 

### DIFF
--- a/src/contacts/models.py
+++ b/src/contacts/models.py
@@ -179,7 +179,7 @@ class PhoneNumber(models.Model):
 	content_object = generic.GenericForeignKey()
 	
 	phone_number = models.CharField(_('number'), max_length=50)
-	location = models.CharField(_('location'), max_length=6,
+	location = models.CharField(_('location'), max_length=128,
 		choices=PHONE_LOCATION_CHOICES, default='work')
 	
 	date_added = models.DateTimeField(_('date added'), auto_now_add=True)
@@ -209,7 +209,7 @@ class EmailAddress(models.Model):
 	content_object = generic.GenericForeignKey()
 	
 	email_address = models.EmailField(_('email address'))
-	location = models.CharField(_('location'), max_length=6,
+	location = models.CharField(_('location'), max_length=128,
 		choices=LOCATION_CHOICES, default='work')
 	
 	date_added = models.DateTimeField(_('date added'), auto_now_add=True)
@@ -245,7 +245,7 @@ class InstantMessenger(models.Model):
 	content_object = generic.GenericForeignKey()
 	
 	im_account = models.CharField(_('im account'), max_length=100)
-	location = models.CharField(_('location'), max_length=6,
+	location = models.CharField(_('location'), max_length=128,
 		choices=LOCATION_CHOICES, default='work')
 	service = models.CharField(_('service'), max_length=11,
 		choices=IM_SERVICE_CHOICES, default='jabber')
@@ -268,7 +268,7 @@ class WebSite(models.Model):
 	content_object = generic.GenericForeignKey()
 
 	url = models.URLField(_('URL'))
-	location = models.CharField(_('location'), max_length=6,
+	location = models.CharField(_('location'), max_length=128,
 		choices=LOCATION_CHOICES, default='work')
 
 	date_added = models.DateTimeField(_('date added'), auto_now_add=True)
@@ -296,7 +296,7 @@ class StreetAddress(models.Model):
 	province = models.CharField(_('province'), max_length=200, blank=True)
 	postal_code = models.CharField(_('postal code'), max_length=10, blank=True)
 	country = models.CharField(_('country'), max_length=100)
-	location = models.CharField(_('location'), max_length=6,
+	location = models.CharField(_('location'), max_length=128,
 		choices=LOCATION_CHOICES, default='work')
 	
 	date_added = models.DateTimeField(_('date added'), auto_now_add=True)


### PR DESCRIPTION
. . . rather than 6.  The six character limit causes problems in my address-book type application by making it difficult for user-defined locations to be input.  Users find it hard to work within 6 characters and say something like "Summer House" or "New York Office" or "Primary Fax."
